### PR TITLE
Update README with correct skill list

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ Skills to assist with Nintendo 64 game decompilation projects.
 
 ## Skills
 
-- **n64-decomp** - Project setup with splat64, ninja build systems, libultra identification, compiler detection
+- **n64-decomp-setup** - N64 game decompilation workflow assistant (project setup, splat64, ninja build systems, libultra identification, compiler detection)
 - **n64-decomp-ido** - IDO compiler build configuration with asm-processor
+- **n64-decomp-splat** - Splat YAML configuration reference
 
 ## Installation
 
@@ -19,6 +20,7 @@ Skills to assist with Nintendo 64 game decompilation projects.
 ### Codex
 
 ```
-$skill-installer install https://github.com/marijnvdwerf/agent-skills/tree/main/skills/n64-decomp
+$skill-installer install https://github.com/marijnvdwerf/agent-skills/tree/main/skills/n64-decomp-setup
 $skill-installer install https://github.com/marijnvdwerf/agent-skills/tree/main/skills/n64-decomp-ido
+$skill-installer install https://github.com/marijnvdwerf/agent-skills/tree/main/skills/n64-decomp-splat
 ```


### PR DESCRIPTION
Updated the README to reflect the actual skills available in the repository.

**Changes:**
- Corrected `n64-decomp` → `n64-decomp-setup`
- Added missing `n64-decomp-splat` skill
- Updated Codex installation instructions for all three skills

Closes #2

Generated with [Claude Code](https://claude.ai/code)